### PR TITLE
Avoid building on other OSes than mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,10 +2,11 @@
   "targets": [
     {
       "target_name": "notificationstate",
-      "sources": [ "lib/notificationstate.cc" ],
+      "sources": [],
       "conditions": [
         ['OS=="mac"', {
           "sources": [
+            "lib/notificationstate.cc",
             "lib/notificationstate-query.cc", 
             "lib/do-not-disturb.mm", 
             "lib/dnd/old-macos-dnd.mm", 


### PR DESCRIPTION
In the current state `electron-rebuild` builds a part of this module even if we are not on a mac, which sometimes causes problems and is unecessary.
Since the upstream repo is slow to merge a PR that contains this useful change, this brings it directly.